### PR TITLE
Show full PV names in tooltips

### DIFF
--- a/archViewer.js
+++ b/archViewer.js
@@ -406,6 +406,7 @@ function fetchDataFromServerAndPlot(xAxisChangeType, newTracePVNames) {
 					x: viewerVars.pvData[pvName].secs,
 					y: viewerVars.pvData[pvName].vals,
 					name: pvName,
+					hoverlabel: {namelength :-1},
 					type: 'scatter',
 					mode: "lines",
 					line: {shape: 'hv'},
@@ -620,6 +621,7 @@ function process3DPlot(pvName, data) {
 				x: range(viewerVars.pvData[pvName].vals[currentFrame].length),
 				y: viewerVars.pvData[pvName].vals[currentFrame],
 				name: pvName,
+				hoverlabel: {namelength :-1},
 				type: 'scatter',
 				yaxis: 'y1'
 		};


### PR DESCRIPTION
This is a very short fix to have display arbitrarily long PV names in svg_viewer (plotly) tooltips.



Screenshots of the viewer before and after the update:
![image](https://user-images.githubusercontent.com/89205155/141747242-15837e6b-0e37-4481-ace4-bd9b6a3535f7.png)
(after the update, it's possible to distinguish between PVs for forward endcap, barrel and backward endcap without referencing the legend)



These changes are based on the suggestion from [https://github.com/plotly/plotly.js/issues/460#issuecomment-457214572](https://github.com/plotly/plotly.js/issues/460#issuecomment-457214572)