### PR TITLE
Wrong csv export format in svgviewer #166

### DIFF
--- a/archViewer.js
+++ b/archViewer.js
@@ -895,9 +895,8 @@ function exportToCSV() {
 }
 
 function viewFile(csvContent) {
-	var encodedUri = encodeURI(csvContent);
 	var link = document.createElement("a");
-	link.setAttribute("href", encodedUri);
+	link.setAttribute("href", csvContent);
 	link.setAttribute("download", toLocal(new Date()) + ".csv");
 	document.body.appendChild(link); // Required for FF
 	link.click(); // This will download the data file named "my_data.csv".


### PR DESCRIPTION
Correction for  Wrong csv export format in svgviewer #166 
CSV export was using twice encodeURI